### PR TITLE
add op: HardSwishNode

### DIFF
--- a/onnx_tool/node.py
+++ b/onnx_tool/node.py
@@ -470,7 +470,7 @@ class HardSwishNode(PWNode):
     def __init__(self, node_proto):
         super().__init__(node_proto)
         self.op_mac = MUL_MACS * 2 + ADD_MACS + CMP_MACS * 2
-        self.add_default_value('alpha',0.2)
+        self.add_default_value('alpha',1/6)
         self.add_default_value('beta',0.5)
 
     def value_infer(self, intensors: []):

--- a/onnx_tool/node.py
+++ b/onnx_tool/node.py
@@ -463,6 +463,19 @@ class HardSigmoidNode(PWNode):
     def value_infer(self, intensors: []):
         y = max(0, min(1, self.alpha * intensors[0] + self.beta))
         return [y]
+    
+
+@NODE_REGISTRY.register()
+class HardSwishNode(PWNode):
+    def __init__(self, node_proto):
+        super().__init__(node_proto)
+        self.op_mac = MUL_MACS * 2 + ADD_MACS + CMP_MACS * 2
+        self.add_default_value('alpha',0.2)
+        self.add_default_value('beta',0.5)
+
+    def value_infer(self, intensors: []):
+        y = intensors[0] * max(0, min(1, self.alpha * intensors[0] + self.beta))
+        return [y]
 
 
 @NODE_REGISTRY.register()


### PR DESCRIPTION
Hi, I was running MobileNet and found that the node "HardSwishNode" was not implemented. So I added the operator. I checked it with this onnx model [mobilenetv3_small_pth.zip](https://github.com/ThanatosShinji/onnx-tool/files/12212258/mobilenetv3_small_pth.zip) and it worked fine.

The corresponding onnx document can be viewed here: https://github.com/onnx/onnx/blob/main/docs/Operators.md#HardSwish 