### PR TITLE
add backward_macs api and print format

### DIFF
--- a/onnx_tool/graph.py
+++ b/onnx_tool/graph.py
@@ -681,7 +681,7 @@ class Graph():
                     continue
                 value_infos.append(vinfo)
             if not with_initializer:
-                 for key in self.initials:
+                for key in self.initials:
                     tensor = self.tensormap[key]
                     vinfo = tensor.make_value_proto()
                     if vinfo is None:
@@ -700,35 +700,35 @@ class Graph():
                 produced_by[tname] = name
 
         consumed_by = {}
-        dependencies={}
+        dependencies = {}
         for name in node_names:
             node = self.nodemap[name]
-            count=0
+            count = 0
             for tname in node.input:
                 if tname in produced_by.keys():
-                    count+=1
+                    count += 1
                     if tname in consumed_by.keys():
                         consumed_by[tname].append(name)
                     else:
                         consumed_by[tname] = [name]
-            dependencies[name]=count
+            dependencies[name] = count
 
         ordered_nodes = []
-        queue =[]
+        queue = []
         while True:
             for name in node_names:
-                if dependencies[name]==0:
+                if dependencies[name] == 0:
                     queue.append(name)
                     ordered_nodes.append(name)
-                    dependencies[name]-=1
-            if len(queue)==0:
+                    dependencies[name] -= 1
+            if len(queue) == 0:
                 break
             for name in queue:
                 node = self.nodemap[name]
                 for o in node.output:
                     if o in consumed_by.keys():
                         for con in consumed_by[o]:
-                            dependencies[con]-=1
+                            dependencies[con] -= 1
             queue.clear()
         return ordered_nodes
 
@@ -1175,7 +1175,7 @@ class Graph():
         for key in self.initials:
             params_flag_map[key] = 0
 
-        self.macs = 0.0
+        self.macs = [0.0, 0.0]
         self.params = 0
         self.memory = 0
         tensors = []
@@ -1225,7 +1225,8 @@ class Graph():
             node.params = _params
             node.memory = _memory
             node.sparsity = block_sparsity
-            self.macs += macs
+            self.macs[0] += macs[0]
+            self.macs[1] += macs[1]
             self.params += _params
             self.memory += _memory
 
@@ -1249,7 +1250,8 @@ class Graph():
 
         ptable = []
 
-        macs = int(round(self.macs))
+        forward_macs = int(round(self.macs[0]))
+        backward_macs = int(round(self.macs[1]))
         params = int(self.params)
         memory = int(self.memory)
 
@@ -1285,7 +1287,8 @@ class Graph():
                 return '{:,}'.format(num)
 
         params += 1e-18
-        macs += 1e-18
+        forward_macs += 1e-18
+        backward_macs += 1e-18
         for key in self.nodemap.keys():
             node = self.nodemap[key]
             if exclude_ops is not None and node.op_type in exclude_ops:
@@ -1296,8 +1299,10 @@ class Graph():
                 row.append(tuple2str(sparsity['blocksize'], splitch))
                 row.append('{:.2%}'.format(sparsity['blockratio']))
                 row.append('{:.2%}'.format(sparsity['ratio']))
-            row.append(num2str(int(node.macs) * factor, csvformat))
-            row.append('{:.2%}'.format(node.macs / macs))
+            row.append(num2str(int(node.macs[0]) * factor, csvformat))
+            row.append('{:.2%}'.format(node.macs[0] / forward_macs))
+            row.append(num2str(int(node.macs[1]) * factor, csvformat))
+            row.append('{:.2%}'.format(node.macs[1] / backward_macs))
             row.append(num2str(int(node.memory), csvformat))
             row.append('{:.2%}'.format(node.memory / memory))
             row.append(num2str(int(node.params), csvformat))
@@ -1311,7 +1316,9 @@ class Graph():
             row.append('_')
             row.append('_')
             row.append('_')
-        row.append(num2str(int(macs * factor), csvformat))
+        row.append(num2str(int(forward_macs * factor), csvformat))
+        row.append('100%')
+        row.append(num2str(int(backward_macs * factor), csvformat))
         row.append('100%')
         row.append(num2str(int(memory), csvformat))
         row.append('100%')
@@ -1326,8 +1333,10 @@ class Graph():
             header.append('Sparse Pattern')
             header.append('Sparse Block Ratio')
             header.append('Sparse Ratio')
-        header.extend([metric, 'CPercent', 'Memory', 'MPercent', 'Params', 'PPercent', 'InShape',
-                       'OutShape'])
+        header.extend(
+            ['Forward_' + metric, 'FPercent', 'Backward_' + metric, 'BPercent', 'Memory', 'MPercent', 'Params',
+             'PPercent', 'InShape',
+             'OutShape'])
 
         if f is None:
             print(tabulate(ptable, headers=header))

--- a/onnx_tool/graph.py
+++ b/onnx_tool/graph.py
@@ -1252,6 +1252,7 @@ class Graph():
 
         forward_macs = int(round(self.macs[0]))
         backward_macs = int(round(self.macs[1]))
+        backward_valid = backward_macs > 0
         params = int(self.params)
         memory = int(self.memory)
 
@@ -1301,8 +1302,9 @@ class Graph():
                 row.append('{:.2%}'.format(sparsity['ratio']))
             row.append(num2str(int(node.macs[0]) * factor, csvformat))
             row.append('{:.2%}'.format(node.macs[0] / forward_macs))
-            row.append(num2str(int(node.macs[1]) * factor, csvformat))
-            row.append('{:.2%}'.format(node.macs[1] / backward_macs))
+            if backward_valid:
+                row.append(num2str(int(node.macs[1]) * factor, csvformat))
+                row.append('{:.2%}'.format(node.macs[1] / backward_macs))
             row.append(num2str(int(node.memory), csvformat))
             row.append('{:.2%}'.format(node.memory / memory))
             row.append(num2str(int(node.params), csvformat))
@@ -1318,8 +1320,9 @@ class Graph():
             row.append('_')
         row.append(num2str(int(forward_macs * factor), csvformat))
         row.append('100%')
-        row.append(num2str(int(backward_macs * factor), csvformat))
-        row.append('100%')
+        if backward_valid:
+            row.append(num2str(int(backward_macs * factor), csvformat))
+            row.append('100%')
         row.append(num2str(int(memory), csvformat))
         row.append('100%')
         row.append(num2str(int(params), csvformat))
@@ -1334,7 +1337,12 @@ class Graph():
             header.append('Sparse Block Ratio')
             header.append('Sparse Ratio')
         header.extend(
-            ['Forward_' + metric, 'FPercent', 'Backward_' + metric, 'BPercent', 'Memory', 'MPercent', 'Params',
+            ['Forward_' + metric, 'FPercent'])
+        if backward_valid:
+            header.extend(
+                ['Backward_' + metric, 'BPercent'])
+        header.extend(
+            ['Memory', 'MPercent', 'Params',
              'PPercent', 'InShape',
              'OutShape'])
 


### PR DESCRIPTION
1. Graph.profile now profiles each node's forward MACs and backward MACs as a MACs list for each node.
2. Add one new column for backward MACs data.
3. fix unregistered bug of QuantizeLinearNode
4. Reformat file