### PR TITLE
Add shape functions and ignore un-consumed outputs

### DIFF
--- a/onnx_tool/graph.py
+++ b/onnx_tool/graph.py
@@ -289,11 +289,12 @@ class Graph():
                         for i, output in enumerate(this_node.output):
                             self.tensormap[output].type = STATIC_TENSOR
                     for output in this_node.output:
-                        for consumer in self.consumedby[output]:
-                            cnode = self.nodemap[consumer]
-                            if self.__is_node_constant__(cnode):
-                                cnode.constant = True
-                                search_nodes.append(consumer)
+                        if output in self.consumedby:
+                            for consumer in self.consumedby[output]:
+                                cnode = self.nodemap[consumer]
+                                if self.__is_node_constant__(cnode):
+                                    cnode.constant = True
+                                    search_nodes.append(consumer)
         self.log(f'Constant Search Time Elapsed {tm.stop()}')
 
     def __update_consumer_producer__(self):

--- a/onnx_tool/node.py
+++ b/onnx_tool/node.py
@@ -808,6 +808,30 @@ class ConcatNode(Node):
         outtensors[0].update_tensor(outtensor)
 
 
+@NODE_REGISTRY.register()
+class GridSampleNode(Node):
+    def __init__(self, n):
+        super().__init__(n)
+
+    def shape_infer(self, intensors: List[Tensor], outtensors: List[Tensor]):
+        r = intensors[1].shape[-1]
+        out_shape = intensors[0].shape[:2] + intensors[1].shape[1:1+r]
+        outtensors[0].update_shape(out_shape)
+        outtensors[0].update_dtype(intensors[0].dtype)
+
+
+@NODE_REGISTRY.register()
+class DepthToSpaceNode(Node):
+    def __init__(self, n):
+        super().__init__(n)
+
+    def shape_infer(self, intensors: List[Tensor], outtensors: List[Tensor]):
+        n, c, h, w = intensors[0].shape
+        b = self.attr["blocksize"]
+        outtensors[0].update_shape([n, c // (b * b), h * b, w * b])
+        outtensors[0].update_dtype(intensors[0].dtype)
+
+
 # copy from https://github.com/onnx/onnx/blob/main/onnx/backend/test/case/node/onehot.py
 def one_hot(indices, depth, axis=-1, dtype=numpy.float32):  # type: ignore
     ''' Compute one hot from indices at a specific axis '''


### PR DESCRIPTION
This PR contains two commits:

    [graph] ignore nodes whose outputs are not consumed
    
    If the input graph contains a node (e.g. an initializer) whose output is
    not consumed by any node, then the graph initialization fails.  More
    specifically, in looking up the list of consumer nodes, the code indexes
    into the `consumedby` dictionary, but the key (i.e. the output
    name) does not exist in the dictionary since the output is unused.
    
    This patch makes a quick fix by first checking whether the output name
    is present in the dictionary before looking up the value in it.

and

    [shape] add shape functions for GridSample and DepthToSpace nodes
    
    This patch registers shape functions for the GridSample and DepthToSpace
    nodes based on the ONNX operator spec.