### PR TITLE
Allow pathlib.Path values as input to Model construction

### DIFF
--- a/onnx_tool/model.py
+++ b/onnx_tool/model.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 import onnx
 
@@ -6,10 +7,13 @@ from .graph import Graph
 
 
 class Model:
-    def __init__(self, m: [str, onnx.ModelProto], verbose=False, constant_folding: bool = True,
+    def __init__(self, m: [str, onnx.ModelProto, pathlib.Path], verbose=False, constant_folding: bool = True,
                  noderename: bool = False):
         self.modelname = ''
-        if isinstance(m, str):
+        if isinstance(m, pathlib.Path):
+            self.modelname = m.name.stem
+            m = onnx.load_model(m)
+        elif isinstance(m, str):
             self.modelname = os.path.basename(m)
             self.modelname = os.path.splitext(self.modelname)[0]
             m = onnx.load_model(m)


### PR DESCRIPTION
Prior to this patch, only string values could be used to specify the
path to the input ONNX file.  However, several Python programs use
values of type `pathlib.Path`, which causes the model creation to
silently fail in onnx-tool.  This patch fixes the problem by allowing
both string paths or `pathlib.Path` paths.

Credit to @xich for discovering the problem!