### PR TITLE
Increase length of default attributes of convolution nodes

### DIFF
--- a/onnx_tool/node.py
+++ b/onnx_tool/node.py
@@ -1668,9 +1668,9 @@ class ConvNode(Node):
     def __init__(self, n):
         super(ConvNode, self).__init__(n)
         self.add_default_value('auto_pad', None)
-        self.add_default_value('pads', (0, 0, 0, 0))
-        self.add_default_value('strides', (1, 1))
-        self.add_default_value('dilations', (1, 1))
+        self.add_default_value('pads', (0, 0, 0, 0, 0, 0))
+        self.add_default_value('strides', (1, 1, 1))
+        self.add_default_value('dilations', (1, 1, 1))
         self.add_default_value('group', 1)
 
     def shape_infer(self, intensors: List[Tensor], outtensors: List[Tensor]):


### PR DESCRIPTION
The size of `pads`, `strides`, and `dilations` attributes depends on the
size of the input tensor, but our default values for these attributes
uses a fixed size (four for `pads`, two for `strides` and `dilations`),
which causes the code to crash when the input tensor is 5D.

We, of course, cannot determine the shape of the input tensor in the
`__init__` function of `ConvNode` (since the input tensor isn't
available), but based on the fact that we only handle up to 5D input
tensors, this patch sets the default value of the attributes to work with
the maximum input size.