### PR TITLE
fix the crash bug when Gemm nodes have a 1-D input

### DIFF
--- a/onnx_tool/node.py
+++ b/onnx_tool/node.py
@@ -727,7 +727,8 @@ class GemmNode(Node):
                 else:
                     macs *= weight_shape[-2]
             else:
-                macs *= weight_shape[-2]
+                if len(weight_shape) > 1:
+                    macs *= weight_shape[-2]
             if len(intensors) == 3:
                 macs += volume(yshape) * ADD_MACS
         else:


### PR DESCRIPTION
in some cases, matmul node will have 1-D cases, which will make onnx_tool.model_profile() crash
as a example, export an onnx model of YOLOv8-seg ([https://github.com/triple-Mu/YOLOv8-TensorRT/blob/main/docs/Segment.md](url)).
Then one of matmul nodes might be like below.
![image](https://github.com/ThanatosShinji/onnx-tool/assets/108714369/d260fe87-573f-460b-b24b-5dd5a7b9fafc)
This node's secend input have only 1 dim, so we should care nothing about it when counting macs, but program will crash when it try to get the -2 dim of the tensor, this PR try to fix that.