### PR TITLE
Fix the shape inference of GridSample when the input is initializer

### DIFF
--- a/onnx_tool/node.py
+++ b/onnx_tool/node.py
@@ -907,7 +907,7 @@ class GridSampleNode(Node):
 
     def shape_infer(self, intensors: List[Tensor], outtensors: List[Tensor]):
         r = intensors[1].shape[-1]
-        out_shape = intensors[0].shape[:2] + intensors[1].shape[1:1 + r]
+        out_shape = list(intensors[0].shape[:2]) + list(intensors[1].shape[1:1+r])
         outtensors[0].update_shape(out_shape)
         outtensors[0].update_dtype(intensors[0].dtype)
 

--- a/onnx_tool/node.py
+++ b/onnx_tool/node.py
@@ -907,7 +907,7 @@ class GridSampleNode(Node):
 
     def shape_infer(self, intensors: List[Tensor], outtensors: List[Tensor]):
         r = intensors[1].shape[-1]
-        out_shape = list(intensors[0].shape[:2]) + list(intensors[1].shape[1:1+r])
+        out_shape = intensors[0].shape[:2] + intensors[1].shape[1:1 + r]
         outtensors[0].update_shape(out_shape)
         outtensors[0].update_dtype(intensors[0].dtype)
 

--- a/onnx_tool/tensor.py
+++ b/onnx_tool/tensor.py
@@ -382,7 +382,8 @@ class Tensor():
             self.name = t.name
             self.proto = t
             self.numpy = tensorproto2ndarray(t)
-            self.shape = self.numpy.shape
+            # NOTE: The shape of the tensor should be a list.
+            self.shape = list(self.numpy.shape)
             self.type = STATIC_TENSOR
             self.dtype = self.numpy.dtype.type
         else:


### PR DESCRIPTION
# Motivtion
The shape inference of GridSampleNode could be crash if the input is initializer.

```
Traceback (most recent call last):
  ...
  File "/home/xxx/miniconda3/envs/torch112cu113/lib/python3.10/site-packages/onnx_tool/__init__.py", line 84, in model_profile
    g.shape_infer(dynamic_shapes)
  File "/home/xxx/miniconda3/envs/torch112cu113/lib/python3.10/site-packages/onnx_tool/graph.py", line 830, in shape_infer
    node.shape_infer(itensors, otensors)
  File "/home/xxx/miniconda3/envs/torch112cu113/lib/python3.10/site-packages/onnx_tool/node.py", line 818, in shape_infer
    out_shape = intensors[0].shape[:2] + intensors[1].shape[1:1+r]
TypeError: can only concatenate list (not "tuple") to list
```

The `intensors[1].shape` would be a tuple if it is a initializer tensor.

# Modification
- onnx_tool/node.py@GridSampleNode
    - Handle the case that input tensor shape is tuple in the `shape_infer`.