### PR TITLE
Add value_infer for GreaterOrEqualNode

### DIFF
--- a/onnx_tool/node.py
+++ b/onnx_tool/node.py
@@ -2174,6 +2174,11 @@ class GreaterNode(Node):
         outshape = outtensors[0].get_shape()
         return [volume(outshape) * CMP_MACS, 0]
 
+@NODE_REGISTRY.register()
+class GreaterOrEqualNode(GreaterNode):
+    def value_infer(self, intensors: List[Tensor], outtensors: List[Tensor]):
+        result = numpy.greater_equal(intensors[0].get_numpy(), intensors[1].get_numpy())
+        outtensors[0].update_tensor(result)
 
 @NODE_REGISTRY.register()
 class DequantizeLinearNode(PWNode):


### PR DESCRIPTION
Hey @ThanatosShinji! Adding `value_infer` to `GreaterOrEqualNode` as it missing, optimization for onnx model fails with error:
```
NotImplementedError: this Node GreaterOrEqual-/GreaterOrEqual_1 has no value_infer
```
It should fix it