### PR TITLE
Fix SplitNode for not evenly splittable input

### DIFF
--- a/onnx_tool/node.py
+++ b/onnx_tool/node.py
@@ -2611,7 +2611,13 @@ class SplitNode(Node):
             if len(intensors) == 2:
                 split = intensors[1].get_numpy()
             else:
-                split = [inshape[self.axis] // 2] * 2
+                if inshape[self.axis] % len(outtensors) == 0:
+                    div = inshape[self.axis] // len(outtensors)
+                    split = [div] * len(outtensors)
+                else:
+                    div = inshape[self.axis] // len(outtensors) + 1
+                    split = [div] * len(outtensors)
+                    split[-1] += inshape[self.axis] - sum(split) 
         else:
             split = self.split
         axis = _axes_neg2pos(len(inshape), [self.axis])[0]
@@ -2640,7 +2646,13 @@ class SplitNode(Node):
             if len(intensors) == 2:
                 split = intensors[1].get_numpy()
             else:
-                split = [inshape[self.axis] // 2]
+                if inshape[self.axis] % len(outtensors) == 0:
+                    div = inshape[self.axis] // len(outtensors)
+                    split = [div] * len(outtensors)
+                else:
+                    div = inshape[self.axis] // len(outtensors) + 1
+                    split = [div] * len(outtensors)
+                    split[-1] += inshape[self.axis] - sum(split) 
         else:
             split = self.split
 


### PR DESCRIPTION
 - Support Split 18 to have more than two output and uneven split
 - No longer have `index out-of-range` error when splitting over a 1-element dimension


Update the calculation of split list according to [onnx official code](https://github.com/onnx/onnx/blob/55f2a1113aedc8d6a9ee42e94de098077d7710bf/onnx/reference/ops/op_split.py#L14)