### PR TITLE
command line option to exclude op type

### DIFF
--- a/onnx_tool/__init__.py
+++ b/onnx_tool/__init__.py
@@ -4,6 +4,8 @@ import warnings
 import numpy
 import onnx
 
+from onnx.defs import get_all_schemas
+
 from .graph import Graph
 from .model import Model
 from .node import NODE_REGISTRY, Node
@@ -67,24 +69,29 @@ DefaultFilter = (
 )
 
 # These ops have no computation
-NoMacsOps = (
+NoMacsOps = {
     'Identity', 'Constant', 'Shape', 'Squeeze', 'Unsqueeze', 'Reshape', 'ConstantOfShape', 'Cast', 'Pad', 'Concat',
     'Slice', 'Gather'
-)
+}
 
 
 def model_profile(m, dynamic_shapes: {str: tuple} = None,
-                  hidden_ops: [str] = NoMacsOps, mcfg={'verbose': False}, save_profile: str = None,
+                  exclude_ops = None, hidden_ops: [str] = NoMacsOps, mcfg={'verbose': False}, save_profile: str = None,
                   save_model: str = None, shape_only:bool=False, no_shape:bool=False) -> None:
     model = loadmodel(m, mcfg)
     g = model.graph
     gtmr = timer()
     g.graph_reorder_nodes()
+    if exclude_ops:
+        all_ops = {op.name for op in get_all_schemas()}
+        for item in exclude_ops:
+            assert item in all_ops, f"Provided exclude op is not a valid onnx op: {item}"
+        hidden_ops.update(exclude_ops)
     gtmr.start()
     g.shape_infer(dynamic_shapes)
     g.log(f'infered all tensor shapes, time cost {gtmr.stop():.3f} s')
     gtmr.start()
-    g.profile()
+    g.profile(exclude_ops=hidden_ops)
     g.log(f'profile all nodes, time cost {gtmr.stop():.3f} s')
     g.print_node_map(save_profile, exclude_ops=hidden_ops)
     if save_model is not None:

--- a/onnx_tool/__main__.py
+++ b/onnx_tool/__main__.py
@@ -28,6 +28,12 @@ def get_parser():
         help='tensor names as: --names 410 420'
     )
     parser.add_argument(
+        '-e',
+        '--exclude-ops',
+        default=None,
+        help="comma seperated list of onnx op types to exclude when profiling: --exclude-ops QuantizeLinear,DequantizeLinear"
+    )
+    parser.add_argument(
         '-d', '--dynamic_shapes',
         nargs='+',
         default=None,
@@ -90,7 +96,8 @@ if args.mode == 'profile':
         dynamic = __args2dynamicshapes__(args.dynamic_shapes)
     else:
         dynamic = None
-    onnx_tool.model_profile(args.in_, dynamic, save_profile=args.file, save_model=args.out)
+    exclude_ops = set(args.exclude_ops.split(",")) if args.exclude_ops else None
+    onnx_tool.model_profile(args.in_, dynamic, exclude_ops=exclude_ops, save_profile=args.file, save_model=args.out)
 elif args.mode == 'export_tensors':
     onnx_tool.model_export_tensors_numpy(args.in_, tensornames=args.names, savefolder=args.out, fp16=args.fp16)
 elif args.mode == 'constant_folding':

--- a/onnx_tool/graph.py
+++ b/onnx_tool/graph.py
@@ -1358,7 +1358,7 @@ class Graph():
 
         return cg
 
-    def profile(self):
+    def profile(self, exclude_ops = None):
         self.valid_profile = False
         if not self.valid_shape:
             warnings.warn('Please perform a valid shape_infer() before profile().')
@@ -1370,7 +1370,8 @@ class Graph():
         self.macs = [0.0, 0.0]
         self.params = 0
         self.memory = 0
-        for key in self.nodemap.keys():
+        ops_to_cover = {k for k, v in self.nodemap.items() if v.op_type not in exclude_ops}
+        for key in ops_to_cover:
             node = self.nodemap[key]
             itensors = []
             _params = 0
@@ -1468,10 +1469,9 @@ class Graph():
         params += 1e-18
         forward_macs += 1e-18
         backward_macs += 1e-18
-        for key in self.nodemap.keys():
+        ops_to_cover = {k for k, v in self.nodemap.items() if v.op_type not in exclude_ops}
+        for key in ops_to_cover:
             node = self.nodemap[key]
-            if exclude_ops is not None and node.op_type in exclude_ops:
-                continue
             row = [key, self.nodemap[key].op_type]
             if print_sparse_table:
                 sparsity = node.sparsity


### PR DESCRIPTION
Ability to exclude nodes by op type from profiler and the report. Optional args `-e x,y,z` or `--exclude-ops x,y,z`
Used the already existing hidden_ops with the addition of user provided exclude ops.
Example can be: 
`-m profile --exclude-ops QuantizeLinear,DequantizeLinear`

Checks to see if user provided op_type is in the onnx schema op list.